### PR TITLE
JAVA-1761: Add OSGi descriptors, upgrade to Guava 25.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
   <groupId>com.datastax.oss</groupId>
   <artifactId>java-driver-shaded-guava</artifactId>
   <version>25.1-jre-SNAPSHOT</version>
+  <packaging>bundle</packaging>
 
   <name>Shaded Guava artifact for use in the DataStax Java driver for Apache Cassandra®</name>
   <description>Shaded Guava artifact for use in the DataStax Java driver for Apache Cassandra®</description>
@@ -30,6 +31,10 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <!-- Note: When upgrading the version, evaluate the following:
+           0. Change the version of the module to match the guava version.
+           1. Update the Export-Package and Import-Package elements in maven-bundle-plugin to match the values in the MANIFEST
+              for the version of guava being upgraded to. -->
       <version>25.1-jre</version>
     </dependency>
   </dependencies>
@@ -97,6 +102,43 @@
           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
           <autoReleaseAfterClose>false</autoReleaseAfterClose>
           <skipLocalStaging>true</skipLocalStaging>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.5.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.datastax.oss.driver.shaded.guava</Bundle-SymbolicName>
+            <!-- Export-Package and Import-Package must be declared explicitly since the maven-bundle-plugin executes before maven-shade-plugin, so the guava classes aren't present at this time.
+                 Note that these should match the specifications from the MANIFEST.mf file of the guava jar this jar will be based on. -->
+            <Export-Package>
+              com.datastax.oss.driver.shaded.guava.common.annotations;version="${project.version}",
+              com.datastax.oss.driver.shaded.guava.common.base;version="${project.version}",
+              com.datastax.oss.driver.shaded.guava.common.cache;version="${project.version}";uses:="com.datastax.oss.driver.shaded.guava.common.base,com.datastax.oss.driver.shaded.guava.common.collect,com.datastax.oss.driver.shaded.guava.common.util.concurrent",
+              com.datastax.oss.driver.shaded.guava.common.collect;version="${project.version}";uses:="com.datastax.oss.driver.shaded.guava.common.base",
+              com.datastax.oss.driver.shaded.guava.common.escape;version="${project.version}";uses:="com.datastax.oss.driver.shaded.guava.common.base",
+              com.datastax.oss.driver.shaded.guava.common.eventbus;version="${project.version}",
+              com.datastax.oss.driver.shaded.guava.common.graph;version="${project.version}";uses:="com.datastax.oss.driver.shaded.guava.common.collect",
+              com.datastax.oss.driver.shaded.guava.common.hash;version="${project.version}";uses:="com.datastax.oss.driver.shaded.guava.common.base",
+              com.datastax.oss.driver.shaded.guava.common.html;version="${project.version}";uses:="com.datastax.oss.driver.shaded.guava.common.escape",
+              com.datastax.oss.driver.shaded.guava.common.io;version="${project.version}";uses:="com.datastax.oss.driver.shaded.guava.common.base,com.datastax.oss.driver.shaded.guava.common.collect,com.datastax.oss.driver.shaded.guava.common.graph,com.datastax.oss.driver.shaded.guava.common.hash",
+              com.datastax.oss.driver.shaded.guava.common.math;version="${project.version}",
+              com.datastax.oss.driver.shaded.guava.common.net;version="${project.version}";uses:="com.datastax.oss.driver.shaded.guava.common.base,com.datastax.oss.driver.shaded.guava.common.collect,com.datastax.oss.driver.shaded.guava.common.escape",
+              com.datastax.oss.driver.shaded.guava.common.primitives;version="${project.version}";uses:="com.datastax.oss.driver.shaded.guava.common.base",
+              com.datastax.oss.driver.shaded.guava.common.reflect;version="${project.version}";uses:="com.datastax.oss.driver.shaded.guava.common.collect,com.datastax.oss.driver.shaded.guava.common.io",
+              com.datastax.oss.driver.shaded.guava.common.util.concurrent;version="${project.version}";uses:="com.datastax.oss.driver.shaded.guava.common.base,com.datastax.oss.driver.shaded.guava.common.collect",
+              com.datastax.oss.driver.shaded.guava.common.xml;version="${project.version}";uses:="com.datastax.oss.driver.shaded.guava.common.escape"
+            </Export-Package>
+            <Import-Package>
+              javax.annotation;resolution:=optional;version="[3.0,4)",
+              javax.crypto;resolution:=optional,
+              javax.crypto.spec;resolution:=optional,
+              sun.misc;resolution:=optional
+            </Import-Package>
+          </instructions>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.datastax.oss</groupId>
   <artifactId>java-driver-shaded-guava</artifactId>
-  <version>24.2-jre-SNAPSHOT</version>
+  <version>25.1-jre-SNAPSHOT</version>
 
   <name>Shaded Guava artifact for use in the DataStax Java driver for Apache Cassandra®</name>
   <description>Shaded Guava artifact for use in the DataStax Java driver for Apache Cassandra®</description>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>24.1-jre</version>
+      <version>25.1-jre</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Motivation:

To enable OSGi support in the DataStax Java drivers, this module must
also support OSGi.

Modifications:

Use maven-bundle-plugin to add OSGi information to the generated
MANIFEST.MF.  Because maven-bundle-plugin runs before
maven-shade-plugin, we also explicitly provide the Export-Package and
Import-Package values, which match the guava jar's values.

Also upgrades to Guava 25.1-jre which was released in May.  Since the
version needs to be increased anyways, this seemed like a good
opportunity to upgrade.

Result:

This module now supports OSGi, upgrades to Guava 25.1-jre.

Generated MANIFEST.MF for reference:

```
Manifest-Version: 1.0                                                                                                                                                                                                                                                                                                                              
Bnd-LastModified: 1528216286603
Build-Jdk: 1.8.0_172
Built-By: andrew.tolbert
Bundle-Description: Shaded Guava artifact for use in the DataStax Java
  driver for Apache Cassandra®
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.txt
Bundle-ManifestVersion: 2
Bundle-Name: Shaded Guava artifact for use in the DataStax Java driver
  for Apache Cassandra®
Bundle-SymbolicName: com.datastax.oss.driver.shaded.guava
Bundle-Version: 25.1.0.jre-SNAPSHOT
Created-By: Apache Maven Bundle Plugin
Export-Package: com.datastax.oss.driver.shaded.guava.common.annotation
 s;version="25.1.0",com.datastax.oss.driver.shaded.guava.common.base;v
 ersion="25.1.0",com.datastax.oss.driver.shaded.guava.common.cache;ver
 sion="25.1.0";uses:="com.datastax.oss.driver.shaded.guava.common.base
 ,com.datastax.oss.driver.shaded.guava.common.collect,com.datastax.oss
 .driver.shaded.guava.common.util.concurrent",com.datastax.oss.driver.
 shaded.guava.common.collect;version="25.1.0";uses:="com.datastax.oss.
 driver.shaded.guava.common.base",com.datastax.oss.driver.shaded.guava
 .common.escape;version="25.1.0";uses:="com.datastax.oss.driver.shaded
 .guava.common.base",com.datastax.oss.driver.shaded.guava.common.event
 bus;version="25.1.0",com.datastax.oss.driver.shaded.guava.common.grap
 h;version="25.1.0";uses:="com.datastax.oss.driver.shaded.guava.common
 .collect",com.datastax.oss.driver.shaded.guava.common.hash;version="2
 5.1.0";uses:="com.datastax.oss.driver.shaded.guava.common.base",com.d
 atastax.oss.driver.shaded.guava.common.html;version="25.1.0";uses:="c
 om.datastax.oss.driver.shaded.guava.common.escape",com.datastax.oss.d
 river.shaded.guava.common.io;version="25.1.0";uses:="com.datastax.oss
 .driver.shaded.guava.common.base,com.datastax.oss.driver.shaded.guava
 .common.collect,com.datastax.oss.driver.shaded.guava.common.graph,com
 .datastax.oss.driver.shaded.guava.common.hash",com.datastax.oss.drive
 r.shaded.guava.common.math;version="25.1.0",com.datastax.oss.driver.s
 haded.guava.common.net;version="25.1.0";uses:="com.datastax.oss.drive
 r.shaded.guava.common.base,com.datastax.oss.driver.shaded.guava.commo
 n.collect,com.datastax.oss.driver.shaded.guava.common.escape",com.dat
 astax.oss.driver.shaded.guava.common.primitives;version="25.1.0";uses
 :="com.datastax.oss.driver.shaded.guava.common.base",com.datastax.oss
 .driver.shaded.guava.common.reflect;version="25.1.0";uses:="com.datas
 tax.oss.driver.shaded.guava.common.collect,com.datastax.oss.driver.sh
 aded.guava.common.io",com.datastax.oss.driver.shaded.guava.common.uti
 l.concurrent;version="25.1.0";uses:="com.datastax.oss.driver.shaded.g
 uava.common.base,com.datastax.oss.driver.shaded.guava.common.collect"
 ,com.datastax.oss.driver.shaded.guava.common.xml;version="25.1.0";use
 s:="com.datastax.oss.driver.shaded.guava.common.escape"
Import-Package: javax.annotation;resolution:=optional;version="[3.0,4)
 ",javax.crypto;resolution:=optional,javax.crypto.spec;resolution:=opt
 ional,sun.misc;resolution:=optional
Tool: Bnd-3.5.0.201709291849
```

Guava 25.1-jre MANIFEST.MF:

```
Manifest-Version: 1.0                                                                                                                                                                                   
Automatic-Module-Name: com.google.common
Bnd-LastModified: 1527098197718
Build-Jdk: 1.8.0_131-google-v7
Built-By: cgdecker
Bundle-Description: Guava is a suite of core and expanded libraries that
  include    utility classes, google's collections, io classes, and much
     much more.
Bundle-DocURL: https://github.com/google/guava/
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.txt
Bundle-ManifestVersion: 2
Bundle-Name: Guava: Google Core Libraries for Java
Bundle-SymbolicName: com.google.guava
Bundle-Version: 25.1.0.jre
Created-By: Apache Maven Bundle Plugin
Export-Package: com.google.common.annotations;version="25.1.0",com.googl
 e.common.base;version="25.1.0",com.google.common.cache;version="25.1.0"
 ;uses:="com.google.common.base,com.google.common.collect,com.google.com
 mon.util.concurrent",com.google.common.collect;version="25.1.0";uses:="
 com.google.common.base",com.google.common.escape;version="25.1.0";uses:
 ="com.google.common.base",com.google.common.eventbus;version="25.1.0",c
 om.google.common.graph;version="25.1.0";uses:="com.google.common.collec
 t",com.google.common.hash;version="25.1.0";uses:="com.google.common.bas
 e",com.google.common.html;version="25.1.0";uses:="com.google.common.esc
 ape",com.google.common.io;version="25.1.0";uses:="com.google.common.bas
 e,com.google.common.collect,com.google.common.graph,com.google.common.h
 ash",com.google.common.math;version="25.1.0",com.google.common.net;vers
 ion="25.1.0";uses:="com.google.common.base,com.google.common.collect,co
 m.google.common.escape",com.google.common.primitives;version="25.1.0";u
 ses:="com.google.common.base",com.google.common.reflect;version="25.1.0
 ";uses:="com.google.common.collect,com.google.common.io",com.google.com
 mon.util.concurrent;version="25.1.0";uses:="com.google.common.base,com.
 google.common.collect",com.google.common.xml;version="25.1.0";uses:="co
 m.google.common.escape"
Import-Package: javax.annotation;resolution:=optional;version="[3.0,4)",
 javax.crypto;resolution:=optional,javax.crypto.spec;resolution:=optiona
 l,sun.misc;resolution:=optional
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool: Bnd-2.3.0.201405100607
```

